### PR TITLE
Fixing references to the home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,14 +17,14 @@
     <section>
   
       <header>
-        <h1><a href="/" title="Tobias Davis" rel="home">Tobias Davis</a></h1>
+        <h1><a href="#!/" title="Tobias Davis" rel="home">Tobias Davis</a></h1>
         <h2>Thoughts of a man interested in science, cryptography, theology, and people.</h2>
         <img role="banner" alt="View of the Loveland Pass, in Colorado, USA." src="/Trail-on-Loveland-Pass-cropped.jpg">
       </header>
   
       <nav role="navigation" title="Main site navigation." class="menu">
         <ul>
-          <li><a href="/" class="active" rel="home" title="Listing of all posts.">Posts.</a></li>
+          <li><a href="#!/" class="active" rel="home" title="Listing of all posts.">Posts.</a></li>
           <li><a href="#!/about.md" title="About the site author.">Something about me.</a></li>
           <li><a href="#!/contact.md" title="Contact the site author.">Talk to me.</a></li>
         </ul>


### PR DESCRIPTION
Adding the hash-bang to the "home" references to prevent page loads when they're clicked